### PR TITLE
Add csv export and eur/usd direct download

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import argparse
 import numpy as np
 import pandas as pd
 import os
+import warnings
 
 parser = argparse.ArgumentParser()
 parser.add_argument('tax_worksheet_csv',
@@ -33,11 +34,16 @@ if os.path.exists(args.eur_usd_csv):
                       delimiter=';')
 else:
     website = 'https://www.bundesbank.de/statistic-rmi/StatisticDownload'
+
+    unable_to_find = 'Unable to find file "' + args.eur_usd_csv + '".'
+    falling_back = 'Falling back to direct download from ' + website
+    warnings.warn(unable_to_find + ' ' + falling_back)
+
     file_name = '?tsId=BBEX3.D.USD.EUR.BB.AC.000&its_csvFormat=en'
     parameters = '&its_fileFormat=csv&mode=its&its_from=' + args.year
     url = website + file_name + parameters
     eur_usd = pd.read_csv(filepath_or_buffer=url,
-                      delimiter=',', skiprows=5, skipfooter=2)
+                      delimiter=',', engine='python', skiprows=5, skipfooter=2)
 
 eur_usd = eur_usd.iloc[8:, :]
 eur_usd = eur_usd.rename(

--- a/app.py
+++ b/app.py
@@ -101,3 +101,5 @@ print('Verluste aus Termingeschäften (Verfall):',
       tax_worksheet.loc[
           np.logical_and(tax_worksheet['CLOSING_TRANSACTION'] == 'EXP',
                          tax_worksheet['GAIN_LOSS'] < 0)]['GAIN_LOSS'].sum())
+
+tax_worksheet.to_csv('tax_results.csv', sep=';')

--- a/app.py
+++ b/app.py
@@ -2,12 +2,15 @@ import argparse
 
 import numpy as np
 import pandas as pd
+import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument('tax_worksheet_csv',
                     help='Tax worksheet (w/o wash sales) from tax center')
 parser.add_argument('eur_usd_csv',
                     help='EUR/USD reference rate from Deutsche Bundesbank')
+parser.add_argument('year',
+                    help='Year to file taxes for')
 args = parser.parse_args()
 
 tax_worksheet = pd.read_csv(filepath_or_buffer=args.tax_worksheet_csv)
@@ -25,8 +28,17 @@ for col in ['CLOSE_DATE', 'OPEN_DATE']:
     tax_worksheet[col] = pd.to_datetime(arg=tax_worksheet[col],
                                         format='%m/%d/%y')
 
-eur_usd = pd.read_csv(filepath_or_buffer=args.eur_usd_csv,
+if os.path.exists(args.eur_usd_csv):
+    eur_usd = pd.read_csv(filepath_or_buffer=args.eur_usd_csv,
                       delimiter=';')
+else:
+    website = 'https://www.bundesbank.de/statistic-rmi/StatisticDownload'
+    file_name = '?tsId=BBEX3.D.USD.EUR.BB.AC.000&its_csvFormat=en'
+    parameters = '&its_fileFormat=csv&mode=its&its_from=' + args.year
+    url = website + file_name + parameters
+    eur_usd = pd.read_csv(filepath_or_buffer=url,
+                      delimiter=',', skiprows=5, skipfooter=2)
+
 eur_usd = eur_usd.iloc[8:, :]
 eur_usd = eur_usd.rename(
     columns={eur_usd.columns[0]: 'DATE', eur_usd.columns[1]: 'EUR_USD_RATE'})


### PR DESCRIPTION
Hi @leonk2210, this PR adds exporting the tax results to a csv file. It also provides a fallback in case the eur/usd exchange rate csv file from Deutsche Bundesbank can't be found. In that case, the csv file will be downloaded directly from their website based on the given year.